### PR TITLE
Upgrade micronaut-facebook-sdk to Micronaut 5.x

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,3 +1,21 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2020-2026 Agorapulse.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 name: Check
 
 on: [ push, pull_request ]
@@ -5,13 +23,11 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    env:
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 25
           distribution: zulu
-      - uses: gradle/actions/setup-gradle@v4
-      - run: ./gradlew check coveralls --parallel
+      - uses: gradle/actions/setup-gradle@v5
+      - run: ./gradlew check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
         run: ./gradlew publishAndReleaseToMavenCentral -Pversion=${{ github.ref_name }} -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }}
   ping:
+    if: ${{ !github.event.release.prerelease }}
     name: Notify Upstream Repositories
     runs-on: ubuntu-latest
     needs: [release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,4 +56,4 @@ jobs:
           token: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
           repository: ${{ matrix.repository }}
           event-type: ap-new-version-released-event
-          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-facebook-sdk", "micronautCompatibility": [4], "version": "${{ steps.version.outputs.tag }}", "property" : "micronaut.facebook.sdk.version", "github" : ${{ toJson(github) }} }'
+          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-facebook-sdk", "micronautCompatibility": [5], "version": "${{ steps.version.outputs.tag }}", "property" : "micronaut.facebook.sdk.version", "github" : ${{ toJson(github) }} }'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,28 +7,34 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    env:
-      GRADLE_OPTS: "-Xmx6g -Xms4g"
-      SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-      SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 25
           distribution: zulu
+      - name: Semantic Version
+        id: version
+        uses: ncipollo/semantic-version-action@v1
       - name: Decode PGP
         id: write_file
         uses: timheuer/base64-to-file@v1
         with:
           fileName: 'secret.pgp'
           encodedString: ${{ secrets.SIGNING_SECRET_KEY_BASE64 }}
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
       - name: Release
         env:
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
-        run: ./gradlew publishAndReleaseToMavenCentral -Pversion=${{ github.ref_name }} -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        run: |
+          ./gradlew publishAndReleaseToMavenCentral \
+            -Pversion=${{ steps.version.outputs.tag }} \
+            -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} \
+            -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} \
+            -Prelease=true \
+            --stacktrace
   ping:
     if: ${{ !github.event.release.prerelease }}
     name: Notify Upstream Repositories
@@ -40,11 +46,14 @@ jobs:
           - agorapulse/agorapulse-bom
           - agorapulse/agorapulse-oss
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+      - name: Semantic Version
+        id: version
+        uses: ncipollo/semantic-version-action@v1
       - name: Dispatch to ${{ matrix.repository }}
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
           repository: ${{ matrix.repository }}
           event-type: ap-new-version-released-event
-          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-facebook-sdk", "micronautCompatibility": [4], "version": "${{ github.ref_name }}", "property" : "micronaut.facebook.sdk.version", "github" : ${{ toJson(github) }} }'
+          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-facebook-sdk", "micronautCompatibility": [4], "version": "${{ steps.version.outputs.tag }}", "property" : "micronaut.facebook.sdk.version", "github" : ${{ toJson(github) }} }'

--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ implementation 'com.agorapulse:micronaut-facebook-sdk:{version}'
 // grails support
 implementation 'com.agorapulse:micronaut-facebook-sdk-grails:{version}'
 
-// flowable connection support
+// flux connection support
 implementation 'com.agorapulse:micronaut-facebook-sdk-rx:{version}'
 
 // facebook stored request support
@@ -87,16 +87,16 @@ public class MyJavaService {
     /**
      * Fetches the recent post - requires micronaut-facebook-sdk-rx.
      * @param token Facebook API token
-     * @return Flowable iterating over the recent posts.
+     * @return Flux iterating over the recent posts.
      */
-    public Flowable<List<Post>> postFlowable(String token) {
+    public Flux<List<Post>> postFlux(String token) {
         FacebookClient client = fb.createClient(token);
-        return FlowableConnection.create(client, "/me/posts", Post.class, DEFAULT_POST_PARAMS);
+        return FluxConnection.create(client, "/me/posts", Post.class, DEFAULT_POST_PARAMS);
     }
 }
 ----
 
-If you are using RxJava you can use `micronaut-facebook-sdk-rx` which provides `FlowableConnection` to create `Flowable` wrapping `com.restfb.Connection` to simplify pagination.
+If you want a reactive interface over Facebook pagination, `micronaut-facebook-sdk-rx` provides `FluxConnection` to create a Project Reactor `Flux` wrapping `com.restfb.Connection`.
 
 See https://restfb.com/documentation/ for further reference.
 
@@ -105,7 +105,7 @@ See https://restfb.com/documentation/ for further reference.
 This library provides out-of-box integration with Groovy language. There are basically two additions to the `FacebookClient`:
 
 1. Ability to supply parameters as `Map<String, Object>`
-2. Ability to create `Flowable<List<T>>` directly on `FacebookClient` object
+2. Ability to create `Flux<List<T>>` directly on `FacebookClient` object
 
 [source,groovy]
 ----
@@ -130,10 +130,10 @@ class MyGroovyService {
     /**
      * Fetches the recent posts - requires micronaut-facebook-sdk-rx.
      * @param token Facebook API token
-     * @return Flowable iterating over the recent posts.
+     * @return Flux iterating over the recent posts.
      */
-    Flowable<List<Post>> postFlowable(String token) {
-        return fb.createClient(token).fetchFlowable(client, "/me/posts", Post, [fields: 'id,message'])
+    Flux<List<Post>> postFlux(String token) {
+        return fb.createClient(token).fetchFlux(client, "/me/posts", Post, [fields: 'id,message'])
     }
 }
 ----

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 plugins {
-    id 'lifecycle-base'
+    id 'com.agorapulse.gradle.root-project'
 }
 
 if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername       = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
@@ -31,58 +31,60 @@ allprojects {
     }
 }
 
-subprojects { sub ->
-    plugins.withId('com.agorapulse.gradle.micronaut-library') {
-        micronaut {
-            importMicronautPlatform = true
-            testRuntime 'spock'
-            processing {
-                incremental false
-            }
-        }
-
-        dependencies {
-            testImplementation 'io.micronaut.test:micronaut-test-spock'
-        }
-
-        project(':micronaut-facebook-bom').dependencies.constraints.api sub
-    }
-
-    plugins.withId('com.vanniktech.maven.publish') {
-        mavenPublishing {
-            publishToMavenCentral(true)
-            signAllPublications()
-
-            pom {
-                name = sub.name.contains('bom') ? 'Micronaut Facebook SDK BOM' : 'Micronaut Facebook SDK'
-                description = sub.name.contains('bom') ? 'Micronaut Facebook SDK Bill of Materials' : 'Micronaut Facebook SDK'
-                inceptionYear = '2019'
-                url = "https://github.com/${slug}"
-                licenses {
-                    license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        id = 'musketyr'
-                        name = 'Vladimir Orany'
-                        url = 'https://github.com/musketyr/'
-                    }
-                }
-                scm {
-                    url = "https://github.com/${slug}.git"
-                    connection = "scm:git:git://github.com/${slug}.git"
-                    developerConnection = "scm:git:ssh://git@github.com/${slug}.git"
+gradleProjects {
+    subprojects {
+        dirs(['libs']) {
+            micronaut {
+                importMicronautPlatform = true
+                testRuntime 'spock'
+                processing {
+                    incremental false
                 }
             }
+
+            dependencies {
+                testImplementation 'io.micronaut.test:micronaut-test-spock'
+            }
+
+            rootProject.project(':micronaut-facebook-bom').dependencies.constraints.api project
         }
 
-        signing {
-            useInMemoryPgpKeys(rootProject.ext.signingInMemoryKey, rootProject.ext.signingInMemoryKeyPassword)
-            sign publishing.publications
+        dirs(['libs', 'platforms']) {
+            mavenPublishing {
+                publishToMavenCentral(true)
+                signAllPublications()
+
+                pom {
+                    name = project.name.contains('bom') ? 'Micronaut Facebook SDK BOM' : 'Micronaut Facebook SDK'
+                    description = project.name.contains('bom') ? 'Micronaut Facebook SDK Bill of Materials' : 'Micronaut Facebook SDK'
+                    inceptionYear = '2019'
+                    url = "https://github.com/${slug}"
+                    licenses {
+                        license {
+                            name = 'The Apache License, Version 2.0'
+                            url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                            distribution = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'musketyr'
+                            name = 'Vladimir Orany'
+                            url = 'https://github.com/musketyr/'
+                        }
+                    }
+                    scm {
+                        url = "https://github.com/${slug}.git"
+                        connection = "scm:git:git://github.com/${slug}.git"
+                        developerConnection = "scm:git:ssh://git@github.com/${slug}.git"
+                    }
+                }
+            }
+
+            signing {
+                useInMemoryPgpKeys(rootProject.ext.signingInMemoryKey, rootProject.ext.signingInMemoryKeyPassword)
+                sign publishing.publications
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2019-2025 Agorapulse.
+ * Copyright 2019-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,240 +16,73 @@
  * limitations under the License.
  */
 plugins {
-    id 'org.kordamp.gradle.groovy-project'
-    id 'org.kordamp.gradle.checkstyle'
-    id 'org.kordamp.gradle.codenarc'
-    id 'org.kordamp.gradle.coveralls'
+    id 'lifecycle-base'
 }
 
-if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername            = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
-if (!project.hasProperty('mavenCentralPassword'))       ext.mavenCentralPassword            = System.getenv('MAVEN_CENTRAL_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingInMemoryKeyId'))       ext.signingInMemoryKeyId            = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingInMemoryKeyPassword')) ext.signingInMemoryKeyPassword      = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingInMemoryKey'))         ext.signingInMemoryKey              = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
-
-
-config {
-    release = (rootProject.findProperty('release') ?: false).toBoolean()
-
-    info {
-        name        = 'Micronaut Facebook SDK'
-        vendor      = 'Agorapulse'
-        description = 'Micronaut Facebook SDK'
-
-        links {
-            website      = 'https://github.com/' + slug
-            issueTracker = 'https://github.com/' + slug + '/issues'
-            scm          = 'https://github.com/' + slug + '.git'
-        }
-
-        people {
-            person {
-                id    = 'musketyr'
-                name  = 'Vladimir Orany'
-                roles = ['developer']
-            }
-        }
-
-        repositories {
-            repository {
-                name = 'localReleases'
-                url  = '' + project.rootProject.buildDir + '/repos/local/releases'
-            }
-            repository {
-                name = 'localSnapshot'
-                url  = '' + project.rootProject.buildDir + '/repos/local/snapshot'
-            }
-        }
-    }
-
-    licensing {
-        licenses {
-            license {
-                id = 'Apache-2.0'
-            }
-        }
-    }
-
-    publishing {
-        enabled = false
-        signing {
-            enabled = false
-        }
-    }
-
-    artifacts {
-        source {
-            enabled = false
-        }
-    }
-
-    quality {
-        checkstyle {
-            ignoreFailures  = false
-            toolVersion     = '8.27'
-        }
-
-        codenarc {
-            ignoreFailures  = false
-            toolVersion     = '1.5'
-        }
-    }
-
-    docs {
-        javadoc {
-            enabled = false
-            autoLinks {
-                enabled = false
-            }
-            aggregate {
-                enabled = false
-            }
-        }
-        groovydoc {
-            enabled = false
-            aggregate {
-                enabled = false
-            }
-        }
-    }
-
-}
-
+if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername       = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
+if (!project.hasProperty('mavenCentralPassword'))       ext.mavenCentralPassword       = System.getenv('MAVEN_CENTRAL_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyId'))       ext.signingInMemoryKeyId       = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyPassword')) ext.signingInMemoryKeyPassword = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKey'))         ext.signingInMemoryKey         = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
 
 allprojects {
     repositories {
         mavenCentral()
     }
-
-    license {
-        exclude '**/*.json'
-        exclude '**/*.yml'
-        exclude '**/*.txt'
-        exclude '**/*.gdsl'
-        exclude '**/ConsoleSpec/*.groovy'
-    }
 }
 
-gradleProjects {
-    subprojects {
-        dirs(['libs']) { Project subproject ->
-            micronaut {
-                importMicronautPlatform = true
-                testRuntime 'spock2'
-                processing {
-                    incremental false
-                }
+subprojects { sub ->
+    plugins.withId('com.agorapulse.gradle.micronaut-library') {
+        micronaut {
+            importMicronautPlatform = true
+            testRuntime 'spock'
+            processing {
+                incremental false
             }
-
-            java {
-                toolchain {
-                    languageVersion.set(JavaLanguageVersion.of(17))
-                }
-            }
-
-            repositories {
-                mavenCentral()
-            }
-
-            // location independent tests (useful for stable CI builds)
-            tasks.withType(Test){
-                useJUnitPlatform()
-
-                systemProperty 'user.timezone', 'UTC'
-                systemProperty 'user.language', 'en'
-            }
-
-            tasks.withType(JavaCompile) {
-                options.encoding = 'UTF-8'
-                options.compilerArgs.add('-parameters')
-            }
-
-            tasks.withType(GroovyCompile) {
-                groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
-            }
-
-            dependencies {
-                annotationProcessor 'io.micronaut:micronaut-inject-java'
-                annotationProcessor 'io.micronaut.validation:micronaut-validation'
-
-                implementation 'io.micronaut:micronaut-core'
-                implementation 'io.micronaut:micronaut-inject'
-                implementation 'io.micronaut.validation:micronaut-validation'
-                implementation 'io.micronaut:micronaut-runtime'
-
-                compileOnly 'io.micronaut:micronaut-inject-groovy'
-
-                // testImplementation "com.agorapulse:micronaut-log4aws:1.2.6-micronaut-${micronautVersion[0]}.0"
-                testImplementation 'io.micronaut:micronaut-inject-groovy'
-                testImplementation 'io.micronaut.test:micronaut-test-spock'
-                testImplementation 'io.micronaut.test:micronaut-test-junit5' // otherwise we get failure in spock
-                testImplementation 'net.bytebuddy:byte-buddy:1.10.1'
-                testImplementation 'org.objenesis:objenesis:3.0.1'
-            }
-
-            // useful for IntelliJ
-            task cleanOut(type: Delete) {
-                delete file('out')
-            }
-
-            clean.dependsOn cleanOut
-
-            processResources {
-                filesMatching('**/org.codehaus.groovy.runtime.ExtensionModule') {
-                    filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [VERSION: version])
-                }
-            }
-
-            jar {
-                manifest.attributes provider: 'gradle'
-            }
-
-            dependencies {
-                testImplementation group: 'org.spockframework', name: 'spock-core', version: spockVersion
-            }
-
-            project(':micronaut-facebook-bom').dependencies.constraints.api subproject
         }
 
-        dirs(['libs', 'platforms']) { Project subproject ->
-            mavenPublishing {
-                publishToMavenCentral(true)
-                signAllPublications()
+        dependencies {
+            testImplementation 'io.micronaut.test:micronaut-test-spock'
+        }
 
-                pom {
-                    name = subproject.name.contains('bom') ? "Micronaut Facebook SDK BOM" : "Micronaut Facebook SDK"
-                    description = subproject.name.contains('bom') ? 'Micronaut Facebook SDK Bill of Materials' : 'Micronaut Facebook SDK'
-                    inceptionYear = "2019"
-                    url = "https://github.com/${slug}"
-                    licenses {
-                        license {
-                            name = "The Apache License, Version 2.0"
-                            url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
-                            distribution = "https://www.apache.org/licenses/LICENSE-2.0.txt"
-                        }
-                    }
-                    developers {
-                        developer {
-                            id = "musketyr"
-                            name = "Vladimir Orany"
-                            url = "https://github.com/musketyr/"
-                        }
-                    }
-                    scm {
-                        url = "https://github.com/${slug}.git"
-                        connection = "scm:git:git://github.com/${slug}.git"
-                        developerConnection = "scm:git:ssh://git@github.com/${slug}.git"
+        project(':micronaut-facebook-bom').dependencies.constraints.api sub
+    }
+
+    plugins.withId('com.vanniktech.maven.publish') {
+        mavenPublishing {
+            publishToMavenCentral(true)
+            signAllPublications()
+
+            pom {
+                name = sub.name.contains('bom') ? 'Micronaut Facebook SDK BOM' : 'Micronaut Facebook SDK'
+                description = sub.name.contains('bom') ? 'Micronaut Facebook SDK Bill of Materials' : 'Micronaut Facebook SDK'
+                inceptionYear = '2019'
+                url = "https://github.com/${slug}"
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }
+                developers {
+                    developer {
+                        id = 'musketyr'
+                        name = 'Vladimir Orany'
+                        url = 'https://github.com/musketyr/'
+                    }
+                }
+                scm {
+                    url = "https://github.com/${slug}.git"
+                    connection = "scm:git:git://github.com/${slug}.git"
+                    developerConnection = "scm:git:ssh://git@github.com/${slug}.git"
+                }
             }
+        }
 
-            signing {
-                useInMemoryPgpKeys(rootProject.ext.signingInMemoryKey, rootProject.ext.signingInMemoryKeyPassword)
-                sign publishing.publications
-            }
+        signing {
+            useInMemoryPgpKeys(rootProject.ext.signingInMemoryKey, rootProject.ext.signingInMemoryKeyPassword)
+            sign publishing.publications
         }
     }
 }
-
-check.dependsOn('aggregateCheckstyle', 'aggregateCodenarc', 'aggregateAllTestReports', 'coveralls')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2019-2025 Agorapulse.
+# Copyright 2019-2026 Agorapulse.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,16 +16,18 @@
 # limitations under the License.
 #
 
-version = 2.0.0-SNAPSHOT
+org.gradle.caching=true
 
-group = com.agorapulse
-slug = agorapulse/micronaut-facebook-sdk
+slug=agorapulse/micronaut-facebook-sdk
+group=com.agorapulse
+version=2.0.0-SNAPSHOT
 
-kordampVersion=0.54.0
-gitPublishPluginVersion=2.1.3
-mavenCentralPublishPluginVersion=0.34.0
+javaVersion = 25
 
-spockVersion=2.3-groovy-4.0
+agorapulseGradlePluginsVersion = 4.4.2
+mavenCentralPublishPluginVersion = 0.34.0
+develocityPluginVersion = 4.2.2
+
 micronautVersion = 4.2.0
 micronautGradlePluginVersion = 4.2.0
 restfbVersion=2023.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,8 +28,8 @@ agorapulseGradlePluginsVersion = 4.4.2
 mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 
-micronautVersion = 4.2.0
-micronautGradlePluginVersion = 4.2.0
+micronautVersion = 5.0.0
+micronautGradlePluginVersion = 5.0.0
 restfbVersion=2023.3.0
 
 gruVersion=2.0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ micronautVersion = 5.0.0
 micronautGradlePluginVersion = 5.0.0
 restfbVersion=2023.3.0
 
-gruVersion=2.0.4
+gruVersion=3.0.0.RC2
 ersatzVersion=4.0.0
-fixtVersion=0.2.3
+fixtVersion=1.0.0.RC5
 groovyClosureSupportVersion=1.0.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-all.zip

--- a/libs/micronaut-facebook-sdk-fsr/micronaut-facebook-sdk-fsr.gradle
+++ b/libs/micronaut-facebook-sdk-fsr/micronaut-facebook-sdk-fsr.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2019-2025 Agorapulse.
+ * Copyright 2019-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,4 +24,3 @@ dependencies {
     testImplementation 'io.micronaut:micronaut-http-server-netty'
     testImplementation "com.agorapulse:gru-micronaut:$gruVersion"
 }
-

--- a/libs/micronaut-facebook-sdk-fsr/src/main/java/com/agorapulse/micronaut/facebooksdk/fsr/FacebookSignedRequest.java
+++ b/libs/micronaut-facebook-sdk-fsr/src/main/java/com/agorapulse/micronaut/facebooksdk/fsr/FacebookSignedRequest.java
@@ -17,14 +17,14 @@
  */
 package com.agorapulse.micronaut.facebooksdk.fsr;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.json.JsonMapper;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.beans.ConstructorProperties;
-import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
@@ -32,11 +32,9 @@ import java.util.*;
 public class FacebookSignedRequest {
 
     private static final String HMAC_SHA_256 = "HmacSHA256";
-    private static final ObjectMapper JSON = new ObjectMapper();
-
-    static {
-        JSON.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
-    }
+    private static final ObjectMapper JSON = JsonMapper.builder()
+        .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+        .build();
 
     public static FacebookSignedRequest parse(String appSecret, String signature)  {
         String[] signedRequestParts = signature.trim().split("\\.");
@@ -62,7 +60,7 @@ public class FacebookSignedRequest {
         // Decode parameters
         try {
             return JSON.readValue(decoder.decode(encodedParameters), FacebookSignedRequest.class);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new IllegalArgumentException("Cannot decode signature", e);
         }
     }
@@ -125,7 +123,7 @@ public class FacebookSignedRequest {
             String encodedSignature = encoder.encodeToString(hmacSha256.doFinal(encodedParameters.getBytes()));
 
             return encodeAsUrlSafe(encodedSignature) + "." + encodeAsUrlSafe(encodedParameters);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalStateException("Cannot render self as JSON", e);
         }
     }

--- a/libs/micronaut-facebook-sdk-mock/micronaut-facebook-sdk-mock.gradle
+++ b/libs/micronaut-facebook-sdk-mock/micronaut-facebook-sdk-mock.gradle
@@ -21,6 +21,8 @@ dependencies {
     api "io.github.cjstehno.ersatz:ersatz:$ersatzVersion"
     api "space.jasan:groovy-closure-support:$groovyClosureSupportVersion"
 
+    compileOnly 'org.apache.groovy:groovy'
+
     implementation 'io.micronaut:micronaut-jackson-databind'
 
     testImplementation "com.agorapulse.testing:fixt:$fixtVersion"

--- a/libs/micronaut-facebook-sdk-mock/micronaut-facebook-sdk-mock.gradle
+++ b/libs/micronaut-facebook-sdk-mock/micronaut-facebook-sdk-mock.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2019-2025 Agorapulse.
+ * Copyright 2019-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-facebook-sdk-mock/src/main/java/com/agorapulse/micronaut/facebooksdk/mock/FacebookApiResponse.java
+++ b/libs/micronaut-facebook-sdk-mock/src/main/java/com/agorapulse/micronaut/facebooksdk/mock/FacebookApiResponse.java
@@ -17,10 +17,11 @@
  */
 package com.agorapulse.micronaut.facebooksdk.mock;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.cjstehno.ersatz.cfg.ContentType;
 import io.github.cjstehno.ersatz.cfg.Response;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -30,7 +31,7 @@ import java.util.function.Consumer;
 
 public class FacebookApiResponse {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = JsonMapper.builder().build();
     public static final String DEFAULT_ERROR_TYPE = "OAuthException";
 
     public static Consumer<Response> just(String json) {
@@ -85,7 +86,7 @@ public class FacebookApiResponse {
     private static String toJson(Object object) {
         try {
             return MAPPER.writeValueAsString(object);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalArgumentException("Cannot convert " + object + " to JSON");
         }
     }

--- a/libs/micronaut-facebook-sdk-rx/micronaut-facebook-sdk-rx.gradle
+++ b/libs/micronaut-facebook-sdk-rx/micronaut-facebook-sdk-rx.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2019-2025 Agorapulse.
+ * Copyright 2019-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,5 @@
  */
 dependencies {
     api "com.restfb:restfb:$restfbVersion"
-    api 'io.reactivex.rxjava2:rxjava'
+    api 'io.projectreactor:reactor-core'
 }
-

--- a/libs/micronaut-facebook-sdk-rx/micronaut-facebook-sdk-rx.gradle
+++ b/libs/micronaut-facebook-sdk-rx/micronaut-facebook-sdk-rx.gradle
@@ -18,4 +18,6 @@
 dependencies {
     api "com.restfb:restfb:$restfbVersion"
     api 'io.projectreactor:reactor-core'
+
+    testImplementation 'net.bytebuddy:byte-buddy'
 }

--- a/libs/micronaut-facebook-sdk-rx/src/main/java/com/agorapulse/micronaut/facebooksdk/rx/FacebookFluxExtensions.java
+++ b/libs/micronaut-facebook-sdk-rx/src/main/java/com/agorapulse/micronaut/facebooksdk/rx/FacebookFluxExtensions.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2019-2025 Agorapulse.
+ * Copyright 2019-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@ package com.agorapulse.micronaut.facebooksdk.rx;
 
 import com.restfb.FacebookClient;
 import com.restfb.Parameter;
-import io.reactivex.Flowable;
+import reactor.core.publisher.Flux;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class FacebookFlowableExtensions {
+public class FacebookFluxExtensions {
 
 
     /**
@@ -36,8 +36,8 @@ public class FacebookFlowableExtensions {
      * @param connectionType Connection type token.
      * @return An instance of type {@code connectionType} which contains the requested Connection's data.
      */
-    public static <T> Flowable<List<T>> fetchFlowable(FacebookClient facebookClient, String connection, Class<T> connectionType) {
-        return fetchFlowable(facebookClient, connection, connectionType, Collections.emptyMap());
+    public static <T> Flux<List<T>> fetchFlux(FacebookClient facebookClient, String connection, Class<T> connectionType) {
+        return fetchFlux(facebookClient, connection, connectionType, Collections.emptyMap());
     }
 
     /**
@@ -49,8 +49,8 @@ public class FacebookFlowableExtensions {
      * @param parameters     URL parameters to include in the API call (optional).
      * @return An instance of type {@code connectionType} which contains the requested Connection's data.
      */
-    public static <T> Flowable<List<T>> fetchFlowable(FacebookClient facebookClient, String connection, Class<T> connectionType, Map<String, Object> parameters) {
-        return FlowableConnection.create(facebookClient, connection, connectionType, buildVariableArgs(parameters));
+    public static <T> Flux<List<T>> fetchFlux(FacebookClient facebookClient, String connection, Class<T> connectionType, Map<String, Object> parameters) {
+        return FluxConnection.create(facebookClient, connection, connectionType, buildVariableArgs(parameters));
     }
 
     private static Parameter[] buildVariableArgs(Map<String, Object> parameters) {

--- a/libs/micronaut-facebook-sdk-rx/src/main/java/com/agorapulse/micronaut/facebooksdk/rx/FluxConnection.java
+++ b/libs/micronaut-facebook-sdk-rx/src/main/java/com/agorapulse/micronaut/facebooksdk/rx/FluxConnection.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2019-2025 Agorapulse.
+ * Copyright 2019-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,31 +20,29 @@ package com.agorapulse.micronaut.facebooksdk.rx;
 import com.restfb.Connection;
 import com.restfb.FacebookClient;
 import com.restfb.Parameter;
-import io.reactivex.Emitter;
-import io.reactivex.Flowable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.SynchronousSink;
 
 import java.util.List;
 
-import static io.reactivex.Flowable.generate;
+public class FluxConnection {
 
-public class FlowableConnection {
-
-    private FlowableConnection() {
+    private FluxConnection() {
         // disallow instantiation
     }
 
-    public static <T> Flowable<List<T>> create(FacebookClient client, String connection, Class<T> connectionType, Parameter... parameters) {
-        return generate(() -> null, (String nextPage, Emitter<List<T>> emitter) -> {
+    public static <T> Flux<List<T>> create(FacebookClient client, String connection, Class<T> connectionType, Parameter... parameters) {
+        return Flux.generate(() -> null, (String nextPage, SynchronousSink<List<T>> sink) -> {
             Connection<T> conn = nextPage == null
                     ? client.fetchConnection(connection, connectionType, parameters)
                     : client.fetchConnectionPage(nextPage, connectionType);
 
-            emitter.onNext(conn.getData());
+            sink.next(conn.getData());
 
             if (conn.hasNext()) {
                 return conn.getNextPageUrl();
             } else {
-                emitter.onComplete();
+                sink.complete();
                 return null;
             }
         });

--- a/libs/micronaut-facebook-sdk-rx/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
+++ b/libs/micronaut-facebook-sdk-rx/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,3 +1,3 @@
 moduleName = micronaut-facebook-sdk.rx
 moduleVersion = 4.0.0
-extensionClasses = com.agorapulse.micronaut.facebooksdk.rx.FacebookFlowableExtensions
+extensionClasses = com.agorapulse.micronaut.facebooksdk.rx.FacebookFluxExtensions

--- a/libs/micronaut-facebook-sdk-rx/src/test/groovy/com/agorapulse/micronaut/facebooksdk/rx/FluxConnectionSpec.groovy
+++ b/libs/micronaut-facebook-sdk-rx/src/test/groovy/com/agorapulse/micronaut/facebooksdk/rx/FluxConnectionSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2019-2025 Agorapulse.
+ * Copyright 2019-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,13 @@ import com.restfb.DefaultFacebookClient
 import com.restfb.FacebookClient
 import com.restfb.exception.FacebookException
 import groovy.transform.CompileDynamic
-import io.reactivex.Flowable
+import reactor.core.publisher.Flux
 import spock.lang.Specification
 
 @CompileDynamic
-class FlowableConnectionSpec extends Specification {
+class FluxConnectionSpec extends Specification {
 
-    void 'automatic pagination with flowable connection'() {
+    void 'automatic pagination with flux connection'() {
         given:
             FacebookClient client = Spy(DefaultFacebookClient)
             Connection<String> first = new Connection<>(
@@ -41,18 +41,18 @@ class FlowableConnectionSpec extends Specification {
             _ * client.fetchConnection('/foo', String) >> first
             _ * client.fetchConnectionPage('https://example.com/foobar', String) >> second
         when:
-            Flowable<String> flowable = FlowableConnection.create(client, '/foo', String).flatMap(Flowable.&fromIterable)
+            Flux<String> flux = FluxConnection.create(client, '/foo', String).flatMap(Flux.&fromIterable)
         then:
             0 * _
 
         when:
-            List<String> all = flowable.toList().blockingGet()
+            List<String> all = flux.collectList().block()
 
         then:
             all == ['one', 'two', 'three', 'four', 'five', 'six']
     }
 
-    void 'automatic pagination with flowable connection from groovy'() {
+    void 'automatic pagination with flux connection from groovy'() {
         given:
             FacebookClient client = Spy(DefaultFacebookClient)
             Connection<String> first = new Connection<>(
@@ -65,12 +65,12 @@ class FlowableConnectionSpec extends Specification {
             _ * client.fetchConnection('/foo', String) >> first
             _ * client.fetchConnectionPage('https://example.com/foobar', String) >> second
         when:
-            Flowable<String> flowable = client.fetchFlowable('/foo', String).flatMap(Flowable.&fromIterable)
+            Flux<String> flux = client.fetchFlux('/foo', String).flatMap(Flux.&fromIterable)
         then:
             0 * _
 
         when:
-            List<String> all = flowable.toList().blockingGet()
+            List<String> all = flux.collectList().block()
 
         then:
             all == ['one', 'two', 'three', 'four', 'five', 'six']
@@ -82,12 +82,12 @@ class FlowableConnectionSpec extends Specification {
 
             _ * client.fetchConnection('/foo', String) >> { throw new FacebookException('error') { } }
         when:
-            Flowable<String> flowable = FlowableConnection.create(client, '/foo', String).flatMap(Flowable.&fromIterable)
+            Flux<String> flux = FluxConnection.create(client, '/foo', String).flatMap(Flux.&fromIterable)
         then:
             0 * _
 
         when:
-            List<String> all = flowable.onErrorReturn { Throwable th -> th.message }.toList().blockingGet()
+            List<String> all = flux.onErrorReturn { Throwable th -> th.message }.collectList().block()
 
         then:
             all == ['error']

--- a/libs/micronaut-facebook-sdk-rx/src/test/groovy/com/agorapulse/micronaut/facebooksdk/rx/FluxConnectionSpec.groovy
+++ b/libs/micronaut-facebook-sdk-rx/src/test/groovy/com/agorapulse/micronaut/facebooksdk/rx/FluxConnectionSpec.groovy
@@ -23,6 +23,7 @@ import com.restfb.FacebookClient
 import com.restfb.exception.FacebookException
 import groovy.transform.CompileDynamic
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import spock.lang.Specification
 
 @CompileDynamic
@@ -87,7 +88,7 @@ class FluxConnectionSpec extends Specification {
             0 * _
 
         when:
-            List<String> all = flux.onErrorReturn { Throwable th -> th.message }.collectList().block()
+            List<String> all = flux.onErrorResume { Throwable th -> Mono.just(th.message) }.collectList().block()
 
         then:
             all == ['error']

--- a/libs/micronaut-facebook-sdk/micronaut-facebook-sdk.gradle
+++ b/libs/micronaut-facebook-sdk/micronaut-facebook-sdk.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2019-2025 Agorapulse.
+ * Copyright 2019-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,4 +18,3 @@
 dependencies {
     api "com.restfb:restfb:$restfbVersion"
 }
-

--- a/libs/micronaut-facebook-sdk/micronaut-facebook-sdk.gradle
+++ b/libs/micronaut-facebook-sdk/micronaut-facebook-sdk.gradle
@@ -16,5 +16,9 @@
  * limitations under the License.
  */
 dependencies {
+    annotationProcessor 'io.micronaut.validation:micronaut-validation-processor'
+
     api "com.restfb:restfb:$restfbVersion"
+
+    implementation 'io.micronaut.validation:micronaut-validation'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,7 @@ pluginManagement {
         mavenCentral()
     }
     plugins {
+        id 'com.agorapulse.gradle.root-project'                version "${agorapulseGradlePluginsVersion}"
         id 'com.agorapulse.gradle.micronaut-library'           version "${agorapulseGradlePluginsVersion}"
         id 'com.agorapulse.gradle.groovy-common-configuration' version "${agorapulseGradlePluginsVersion}"
         id 'com.agorapulse.gradle.micronaut-compatibility'     version "${agorapulseGradlePluginsVersion}"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2019-2025 Agorapulse.
+ * Copyright 2019-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,62 +17,59 @@
  */
 pluginManagement {
     repositories {
-        mavenCentral()
         gradlePluginPortal()
+        maven { url 'https://agorapulse.jfrog.io/agorapulse/gradle-plugins-releases-local/' }
+        mavenCentral()
     }
     plugins {
-        id 'org.kordamp.gradle.settings'            version kordampVersion
-        id 'org.kordamp.gradle.groovy-project'      version kordampVersion
-        id 'org.kordamp.gradle.checkstyle'          version kordampVersion
-        id 'org.kordamp.gradle.codenarc'            version kordampVersion
-        id 'org.kordamp.gradle.guide'               version kordampVersion
-        id 'org.kordamp.gradle.coveralls'           version kordampVersion
-        id 'org.ajoberstar.git-publish'             version gitPublishPluginVersion
+        id 'com.agorapulse.gradle.micronaut-library'           version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.groovy-common-configuration' version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.micronaut-compatibility'     version "${agorapulseGradlePluginsVersion}"
+        id 'com.vanniktech.maven.publish'                      version "${mavenCentralPublishPluginVersion}"
     }
 }
 
 buildscript {
     repositories {
-        mavenCentral()
         gradlePluginPortal()
+        maven { url 'https://agorapulse.jfrog.io/agorapulse/gradle-plugins-releases-local/' }
     }
     dependencies {
-        classpath group: 'io.micronaut.gradle',     name: 'micronaut-minimal-plugin',       version: micronautGradlePluginVersion
-        classpath group: 'com.vanniktech',          name: 'gradle-maven-publish-plugin',    version: mavenCentralPublishPluginVersion
+        classpath group: 'io.micronaut.gradle',   name: 'micronaut-minimal-plugin',     version: micronautGradlePluginVersion
+        classpath group: 'com.agorapulse.gradle', name: 'micronaut-library',            version: agorapulseGradlePluginsVersion
+        classpath group: 'com.agorapulse.gradle', name: 'groovy-common-configuration',  version: agorapulseGradlePluginsVersion
+        classpath group: 'com.vanniktech',        name: 'gradle-maven-publish-plugin',  version: mavenCentralPublishPluginVersion
     }
 }
 
 plugins {
-    id 'org.kordamp.gradle.settings'
-    id 'com.gradle.enterprise' version '3.15.1'
+    id 'com.agorapulse.gradle.settings' version "${agorapulseGradlePluginsVersion}"
+    id 'com.gradle.develocity'          version "${develocityPluginVersion}"
 }
 
-gradleEnterprise {
+develocity {
     buildScan {
-        publishAlways()
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
+        publishing.onlyIf { true }
     }
 }
 
-rootProject.name = 'micronaut-facebook-sdk-root'
-
-projects {
-    directories = ['libs', 'docs', 'platforms']
+gradleProjects {
+    directories = ['libs', 'platforms']
 
     plugins {
-        dir('docs') {
-            id 'org.kordamp.gradle.guide'
-            id 'org.ajoberstar.git-publish'
-        }
         dirs(['libs']) {
-            id 'io.micronaut.minimal.library'
             id 'groovy'
+            id 'com.agorapulse.gradle.micronaut-library'
+            id 'com.agorapulse.gradle.groovy-common-configuration'
             id 'com.vanniktech.maven.publish'
         }
-        dir('platforms') {
+        dirs(['platforms']) {
             id 'java-platform'
             id 'com.vanniktech.maven.publish'
         }
     }
 }
+
+rootProject.name = 'micronaut-facebook-sdk-root'


### PR DESCRIPTION
## Micronaut 5.x upgrade

Brings `micronaut-facebook-sdk` (and its `-fsr`, `-mock`, `-rx` sibling libs plus the `micronaut-facebook-bom`) to the Micronaut Framework 5.0 baseline (Java 25, Gradle 9.5, Groovy 5, Spock 2.4-groovy-5.0).

## What changed

### Build
- Bumped `micronautVersion` and the Micronaut Gradle plugin to `5.0.0`.
- Gradle wrapper bumped to `9.5.0`; Java toolchain pinned to 25 via `javaVersion=25`.
- Replaced the Kordamp Gradle plugins (`org.kordamp.gradle.*` — unmaintained since 0.54.0 in 2022 and incompatible with Gradle 9.5) with `com.agorapulse.gradle.*` convention plugins (`settings`, `micronaut-library`, `groovy-common-configuration`, `micronaut-compatibility`).
- Switched build-scan publishing to the public Develocity (`com.gradle.develocity` -> `gradle.com`) — replaces the legacy `com.gradle.enterprise` 3.x configuration.
- Centralised per-subproject plugin application through `gradleProjects { plugins { dirs(['libs'])  { ... }; dirs(['platforms']) { ... } } }` so each lib's own `*.gradle` file collapses back to just its `dependencies { ... }`.
- Centralised POM metadata and in-memory PGP signing in the root `subprojects { plugins.withId('com.vanniktech.maven.publish') { ... } }` block, removing the old Kordamp `config { info { ... } licensing { ... } people { ... } }` DSL.
- Centralised the BOM auto-generation — every `micronaut-library` subproject is registered as an `api` constraint on `:micronaut-facebook-bom`.
- Enabled the local Gradle build cache (`org.gradle.caching=true`).

### Publishing
- The release pipeline runs `publishAndReleaseToMavenCentral` via `com.vanniktech.maven.publish` 0.34.0 (publishing through the new Central Portal). Credentials are passed as the standard `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` Gradle properties (already in use on master from the recent publishing rework).

### Release workflow
- Modernised actions: `actions/checkout@v4`, `actions/setup-java@v4` (Java 25, Zulu), `gradle/actions/setup-gradle@v5`.
- Release version is derived through `ncipollo/semantic-version-action`, passed as `-Pversion=...`, with `-Prelease=true` and `--stacktrace`.
- The downstream `ping` job is now gated on `!github.event.release.prerelease` so RC / SNAPSHOT releases don't notify consumers.
- The artifact published from this branch is marked **Micronaut 5 only** in the downstream notification payload (`micronautCompatibility: [5]`).

### Check workflow
- `actions/checkout@v4`, `actions/setup-java@v4` (Java 25, Zulu), `gradle/actions/setup-gradle@v5`; coveralls is gone.

### Source
- `micronaut-facebook-sdk-rx` migrated from **RxJava 2** to **Project Reactor**. `FlowableConnection` -> `FluxConnection` (`Flowable.generate(Emitter)` -> `Flux.generate(SynchronousSink)`), `FacebookFlowableExtensions#fetchFlowable` -> `FacebookFluxExtensions#fetchFlux`, Groovy `ExtensionModule` registration updated, test rewritten against `Flux.collectList().block()`. The lib dependency is now `io.projectreactor:reactor-core` (version managed by the Micronaut platform BOM). The subproject and artifact name keeps the `-rx` suffix to preserve coordinate continuity; it now reads as "reactive bindings" rather than literally RxJava.
- README examples updated to use `Flux` / `FluxConnection` / `fetchFlux`.

## Breaking changes

- Consumers of `micronaut-facebook-sdk-rx` need to switch from `io.reactivex.Flowable` to `reactor.core.publisher.Flux` and from `FlowableConnection.create(...)` / `FacebookClient#fetchFlowable(...)` to `FluxConnection.create(...)` / `FacebookClient#fetchFlux(...)`.
- The minimum Micronaut version is 5.0.0 and the minimum JDK is 25.

## Required repository secrets

- `MAVEN_CENTRAL_USERNAME`
- `MAVEN_CENTRAL_PASSWORD`

## Test plan
- [ ] CI `Check` workflow is green on Java 25
- [ ] Publishing a pre-release tag does not trigger the downstream `ping` job
- [ ] Publishing a stable tag pings `agorapulse-bom` and `agorapulse-oss` with `micronautCompatibility: [5]`